### PR TITLE
docs(Angular): fix incorrect `db` reference in populate() example

### DIFF
--- a/docs/Tutorial/Angular.md
+++ b/docs/Tutorial/Angular.md
@@ -57,10 +57,10 @@ export class AppDB extends Dexie {
   }
 
   async populate() {
-    const todoListId = await db.todoLists.add({
+    const todoListId = await this.todoLists.add({
       title: 'To Do Today',
     });
-    await db.todoItems.bulkAdd([
+    await this.todoItems.bulkAdd([
       {
         todoListId,
         title: 'Feed the birds',


### PR DESCRIPTION
Fix: use `this` instead of `db` inside AppDB.populate() method

The populate() method was referencing the module-level `db` variable before it was declared. While this works due to JavaScript's execution timing (the callback runs after instantiation), it's technically incorrect and could cause unexpected behavior with multiple instances.

Changed `db.todoLists` → `this.todoLists` and `db.todoItems` → `this.todoItems`