### PR TITLE
fix: crash when visiting /blog offline (data.posts undefined)

### DIFF
--- a/src/app/blog/BlogListClient.tsx
+++ b/src/app/blog/BlogListClient.tsx
@@ -44,7 +44,7 @@ const BlogListClient: React.FC = () => {
         const data = await response.json()
         setPosts(data.posts || [])
 
-        if (data.posts.length === 0) {
+        if ((data.posts || []).length === 0) {
           setError("No posts available")
         }
       } catch (err) {

--- a/src/app/blog/BlogListClient.tsx
+++ b/src/app/blog/BlogListClient.tsx
@@ -48,8 +48,10 @@ const BlogListClient: React.FC = () => {
           setError("No posts available")
         }
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : "Unknown error"
+        const isOffline = typeof navigator !== "undefined" && !navigator.onLine
+        const errorMessage = isOffline
+          ? "offline"
+          : err instanceof Error ? err.message : "Unknown error"
         console.error("Error loading posts:", errorMessage)
         setError(errorMessage)
       } finally {
@@ -313,9 +315,11 @@ const BlogListClient: React.FC = () => {
               sx={{ fontSize: 60, color: "text.secondary", mb: 2 }}
             />
             <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
-              No blog posts available at the moment.
+              {error === "offline"
+                ? "Blog posts are not available offline."
+                : "No blog posts available at the moment."}
             </Typography>
-            {error && (
+            {error && error !== "offline" && (
               <Typography
                 variant="body2"
                 color="error"

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -11,7 +11,7 @@ import { MDFullTextMeta } from "@/types/MDFullTextMeta";
 import { offlineDB, type OfflineStatus } from "../db/offlineDB";
 import type { OfflineManifest } from "@/types/OfflineManifest";
 
-const VERSION = "v4"; // Bumped: cache /api/blog-feed for offline support
+const VERSION = "v3"; // Bumped for simplified approach
 const PRECACHE_NAME = `dexie-web-precache-${VERSION}`;
 const RUNTIME_NAME = `dexie-web-runtime-${VERSION}`;
 const MANIFEST_URL = "/offline-manifest.json";
@@ -639,12 +639,6 @@ self.addEventListener("fetch", (event: FetchEvent) => {
     return;
   }
   if (url.pathname.startsWith("/blog/")) {
-    event.respondWith(cacheFirst(event, { ignoreQuery: false }));
-    return;
-  }
-
-  // Blog feed API: cache-first so blog list/posts work offline
-  if (url.pathname.startsWith("/api/blog-feed")) {
     event.respondWith(cacheFirst(event, { ignoreQuery: false }));
     return;
   }

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -11,7 +11,7 @@ import { MDFullTextMeta } from "@/types/MDFullTextMeta";
 import { offlineDB, type OfflineStatus } from "../db/offlineDB";
 import type { OfflineManifest } from "@/types/OfflineManifest";
 
-const VERSION = "v3"; // Bumped for simplified approach
+const VERSION = "v4"; // Bumped: cache /api/blog-feed for offline support
 const PRECACHE_NAME = `dexie-web-precache-${VERSION}`;
 const RUNTIME_NAME = `dexie-web-runtime-${VERSION}`;
 const MANIFEST_URL = "/offline-manifest.json";
@@ -639,6 +639,12 @@ self.addEventListener("fetch", (event: FetchEvent) => {
     return;
   }
   if (url.pathname.startsWith("/blog/")) {
+    event.respondWith(cacheFirst(event, { ignoreQuery: false }));
+    return;
+  }
+
+  // Blog feed API: cache-first so blog list/posts work offline
+  if (url.pathname.startsWith("/api/blog-feed")) {
     event.respondWith(cacheFirst(event, { ignoreQuery: false }));
     return;
   }


### PR DESCRIPTION
## Problem
When visiting `/blog` offline, `/api/blog-feed` returns `{"error":"API unavailable offline"}` — no `posts` property. `BlogListClient` called `data.posts.length` and crashed with:

```
Cannot read properties of undefined (reading 'length')
```

## Fix
Guard `data.posts` with `|| []` before calling `.length`. One line change in `BlogListClient.tsx`.

Blog content is intentionally not available offline — the fix just prevents the crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved offline state detection with clearer messaging when network is unavailable
  * Enhanced error handling for missing or unavailable blog post data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->