### PR TITLE
fix(docs): restore side-by-side arch diagram with plain ASCII alignment

### DIFF
--- a/docs/cloud/blob-offloading.md
+++ b/docs/cloud/blob-offloading.md
@@ -145,28 +145,22 @@ blobProgress.subscribe(progress => {
 +------------------+
 |   Application    |
 |   (Blob/File)    |
-+---------+--------+
-          |
-          | store
-          v
-+---------+--------+
++--------+---------+
+         |
+         | store
+         v
++--------+---------+
 |    IndexedDB     |
-|  (local cache)   |
-+---------+--------+
-          |
-          | sync
-          v
-+---------+--------+
-|   Dexie Cloud    |
-|      Server      |
-+---------+--------+
-          |
-          | store
-          v
-+---------+--------+
-|   Blob Storage   |
-| (PostgreSQL/S3)  |
-+------------------+
+|   (local cache)  |
++--------+---------+
+         |
+         | sync
+         v
++--------+---------+    +------------------+
+|   Dexie Cloud    |--->|   Blob Storage   |
+|     Server       |    |  (PostgreSQL or  |
+|                  |    |      S3)         |
++------------------+    +------------------+
 ```
 
 ### Server-Side Storage


### PR DESCRIPTION
Restores the original two-column architecture diagram but replaces Unicode box-drawing chars with plain ASCII (+, -, |, v, --->) so connector lines align correctly in all monospace fonts.