### PR TITLE
docs(rest-api): migrate TSON imports from dreambase-library to dexie-cloud-common

### DIFF
--- a/docs/cloud/rest-api.md
+++ b/docs/cloud/rest-api.md
@@ -46,10 +46,10 @@ Blob objects:
 
 ### Parsing Special Types
 
-To properly parse JSON responses that contain these special types, use the `TypesonSimplified` utility from the `dreambase-library`:
+To properly parse JSON responses that contain these special types, use the `TypesonSimplified` utility from the `dexie-cloud-common` package:
 
 ```ts
-import { TypesonSimplified, builtInTypeDefs } from 'dreambase-library'
+import { TypesonSimplified, builtInTypeDefs } from 'dexie-cloud-common'
 
 export const TSON = TypesonSimplified(builtInTypeDefs)
 
@@ -101,14 +101,14 @@ To download the actual binary data, use the [/blob/ endpoint](#blob-endpoint) wi
 When sending data to POST endpoints, use `TSON.stringify()` instead of `JSON.stringify()` to properly serialize special types:
 
 ```ts
-import { FakeBlob } from 'dreambase-library'
+import { TypesonSimplified, builtInTypeDefs, FakeBlob } from 'dexie-cloud-common'
+
+export const TSON = TypesonSimplified(builtInTypeDefs)
 
 const data = {
   name: 'Example',
   createdAt: new Date(),
-  attachment: new FakeBlob(Buffer.from('hello world', 'utf8').buffer, {
-    type: 'text/plain',
-  }),
+  attachment: new FakeBlob(Buffer.from('hello world', 'utf8').buffer, 'text/plain'),
 }
 
 const response = await fetch(`${databaseUrl}/my/table`, {


### PR DESCRIPTION
## Summary

The TSON implementation (`TypesonSimplified`, `builtInTypeDefs`, `FakeBlob`) was migrated from `dreambase-library` into `dexie-cloud-common` back in 2026-02-10. The code examples in the REST API documentation were still referencing the old package.

## Changes

- Updated both code examples to import from `dexie-cloud-common` instead of `dreambase-library`
- In the "Creating JSON with Special Types" example, the `FakeBlob` import was previously a standalone import — added the full TSON setup (`TypesonSimplified`, `builtInTypeDefs`) to make it a self-contained, copy-pasteable example
- **Bug fix:** The `FakeBlob` constructor call was wrong: `new FakeBlob(buf, { type: 'text/plain' })` → should be `new FakeBlob(buf, 'text/plain')` — the second argument is a plain `string`, not an object

## Verification

Checked the actual source in `dexie-cloud-common`:
```ts
// dexie-cloud-common/src/tson/FakeBlob.ts
export class FakeBlob {
  constructor(
    public buf: ArrayBuffer,
    public type?: string  // plain string, not { type: string }
  ) {}
}
```

Both `TypesonSimplified` and `builtInTypeDefs` are exported from the top-level `dexie-cloud-common` index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated REST API documentation code examples with corrected import statements and revised JSON type handling serialization format.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dexie/dexie-web/pull/43)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->