### PR TITLE
fix(sw): add dexie-logo.png to service worker precache

### DIFF
--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -11,7 +11,7 @@ import { MDFullTextMeta } from "@/types/MDFullTextMeta";
 import { offlineDB, type OfflineStatus } from "../db/offlineDB";
 import type { OfflineManifest } from "@/types/OfflineManifest";
 
-const VERSION = "v4"; // Added dexie-logo.png to precache
+const VERSION = "v3"; // Bumped for simplified approach
 const PRECACHE_NAME = `dexie-web-precache-${VERSION}`;
 const RUNTIME_NAME = `dexie-web-runtime-${VERSION}`;
 const MANIFEST_URL = "/offline-manifest.json";

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -11,7 +11,7 @@ import { MDFullTextMeta } from "@/types/MDFullTextMeta";
 import { offlineDB, type OfflineStatus } from "../db/offlineDB";
 import type { OfflineManifest } from "@/types/OfflineManifest";
 
-const VERSION = "v3"; // Bumped for simplified approach
+const VERSION = "v4"; // Added dexie-logo.png to precache
 const PRECACHE_NAME = `dexie-web-precache-${VERSION}`;
 const RUNTIME_NAME = `dexie-web-runtime-${VERSION}`;
 const MANIFEST_URL = "/offline-manifest.json";
@@ -180,6 +180,7 @@ self.addEventListener("install", (event: ExtendableEvent) => {
           "/",
           "/docs",
           "/favicon.ico",
+          "/assets/images/dexie-logo.png",
           "/assets/images/og-images/og-base.png",
         ].map((u) => new Request(u, { credentials: "same-origin" }))
       );


### PR DESCRIPTION
## Problem

The Dexie logo in the top-left navbar showed as a broken image when offline. The logo was never added to the service worker's install-time precache list, so it wasn't available when the network was gone.

## Fix

Add `/assets/images/dexie-logo.png` to the `precache.addAll()` call in the `install` event handler in `src/sw/sw.ts`.

Also bumps `VERSION` from `v3` → `v4` so existing SW installs pick up the new precache on next activation.