### PR TITLE
Add redirect: strip .html suffix from all URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,11 @@ const nextConfig: NextConfig = {
         destination: "/pricing",
         permanent: false,
       },
+      {
+        source: "/:path*.html",
+        destination: "/:path*",
+        permanent: true,
+      },
     ]
   },
 }


### PR DESCRIPTION
## Problem

Old dexie.org served pages with `.html` extensions. Crawlers and bots (some dating back to 2018) still request URLs like:

```
/docs/DexieErrors/Dexie.PrematureCommitError.html
```

These currently 404, even though the page exists at `/docs/DexieErrors/Dexie.PrematureCommitError`.

## Fix

Added a catch-all 301 redirect in `next.config.ts` that strips `.html` from any URL:

```ts
{
  source: "/:path*.html",
  destination: "/:path*",
  permanent: true,
}
```

## Testing

Please test locally:
1. Run `npm run dev`
2. Visit http://localhost:3000/docs/DexieErrors/Dexie.PrematureCommitError.html — should redirect to `/docs/DexieErrors/Dexie.PrematureCommitError`
3. Verify other pages still work normally

/cc Liz — please review, test and merge if it looks good!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic URL redirects to remove `.html` file extensions from page paths, ensuring cleaner, standardized URLs for all users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dexie/dexie-web/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->