### PR TITLE
fix(sw): check PRECACHE_NAME as fallback in cacheFirst — fixes offline logo

### DIFF
--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -519,7 +519,10 @@ async function cacheFirst(
   const canonicalUrl = ignoreQuery ? request.url.split("?")[0] : request.url;
 
   // For ALL other requests (prefetch, assets, etc.), use cache-first
-  let cached = await cache.match(canonicalUrl);
+  let cached =
+    (await cache.match(canonicalUrl)) ||
+    // Fallback: check precache (e.g. dexie-logo.png added at install time)
+    (await caches.open(PRECACHE_NAME).then((c) => c.match(canonicalUrl)));
 
   // If not found and this is a docs route, try case-insensitive variants
   if (!cached && canonicalUrl.startsWith(`${ORIGIN}/docs/`)) {


### PR DESCRIPTION
## Problem
Dexie logo (`/assets/images/dexie-logo.png`) was precached at install time into `PRECACHE_NAME` (`dexie-web-precache-v3`), but the `cacheFirst()` function only looks in `RUNTIME_NAME` (`dexie-web-runtime-v3`). The two caches are separate — so the logo was stored but never served offline.

## Fix
Add a fallback lookup in `PRECACHE_NAME` when the runtime cache misses:

```ts
let cached =
  (await cache.match(canonicalUrl)) ||
  (await caches.open(PRECACHE_NAME).then((c) => c.match(canonicalUrl)));
```

This means precached assets (logo, favicon, og-base.png) are now served from the precache when they haven't been picked up by the manifest-driven runtime cache yet.

## Root cause
PR #45 correctly added the logo to the precache list — but the `cacheFirst()` serving path was never updated to check the precache as fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline functionality to ensure more app resources and assets remain accessible when users are without internet connectivity, enhancing the overall offline experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dexie/dexie-web/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->