### PR TITLE
docs: add clear-table and clear-realm CLI commands

### DIFF
--- a/docs/cloud/cli.md
+++ b/docs/cloud/cli.md
@@ -575,7 +575,7 @@ Requires `GLOBAL_WRITE` scope. This also removes any blobs and Y.js documents as
 
 _Since dexie-cloud@3.0.4_
 
-Removes all objects, members, and Y.js data belonging to a specific realm across all tables. Validates shard availability upfront (all-or-nothing) to prevent partial deletes.
+Removes all objects, members, and Y.js data belonging to a specific realm across all tables. Validates shard availability upfront (all-or-nothing) to prevent partial deletes. Since every user store their private data on a fictive realmId that corresponds to their user id, clear-realm can also be used to wipe out all private data for a certain user.
 
 ```
 npx dexie-cloud clear-realm <realmId>
@@ -592,10 +592,13 @@ npx dexie-cloud clear-realm <realmId>
 
 ```
 # Clear all data from a specific realm (prompts for confirmation)
-npx dexie-cloud clear-realm rlm-xyz123
+npx dexie-cloud clear-realm "rlm-xyz123"
 
 # Skip confirmation
-npx dexie-cloud clear-realm rlm-xyz123 --yes
+npx dexie-cloud clear-realm "rlm-xyz123" --yes
+
+# Clear all data for a certain user
+npx dexie-cloud clear-realm "foo@bar.com"
 ```
 
 ### Remarks

--- a/docs/cloud/cli.md
+++ b/docs/cloud/cli.md
@@ -542,11 +542,11 @@ use the `npx dexie-cloud reset` command.
 
 ## clear-table
 
-_Since dexie-cloud@3.0.4_
+_Since dexie-cloud CLI version 3.0.4 (dexie-cloud@3.0.4)_
 
-Wipes all objects from a given table in the database without deleting the database itself. Useful for resetting test data or performing targeted data cleanup.
+Wipes all objects from a given table in the database. Useful for resetting test data or performing targeted data cleanup.
 
-```
+```bash
 npx dexie-cloud clear-table <table>
 ```
 
@@ -559,7 +559,7 @@ npx dexie-cloud clear-table <table>
 
 ### Example
 
-```
+```bash
 # Clear all items from the 'todoItems' table (prompts for confirmation)
 npx dexie-cloud clear-table todoItems
 
@@ -573,7 +573,7 @@ Requires `GLOBAL_WRITE` scope. This also removes any blobs and Y.js documents as
 
 ## clear-realm
 
-_Since dexie-cloud@3.0.4_
+_Since dexie-cloud CLI version 3.0.4 (dexie-cloud@3.0.4)_
 
 Removes all objects, members, and Y.js data belonging to a specific realm across all tables. Validates shard availability upfront (all-or-nothing) to prevent partial deletes. Since every user store their private data on a fictive realmId that corresponds to their user id, clear-realm can also be used to wipe out all private data for a certain user.
 
@@ -590,7 +590,7 @@ npx dexie-cloud clear-realm <realmId>
 
 ### Example
 
-```
+```bash
 # Clear all data from a specific realm (prompts for confirmation)
 npx dexie-cloud clear-realm "rlm-xyz123"
 

--- a/docs/cloud/cli.md
+++ b/docs/cloud/cli.md
@@ -540,6 +540,68 @@ However, Dexie Cloud don't care about secondary indexes (so far) - the only info
 Just like in the client-side dexie schema, omitting a table doesn't mean deleting it. Explicitly set it to null in order to delete a table. A deleted table in the cloud does not delete its content - it is possible to bring the data back. In order to reset a table or database completely,
 use the `npx dexie-cloud reset` command.
 
+## clear-table
+
+_Since dexie-cloud@3.0.4_
+
+Wipes all objects from a given table in the database without deleting the database itself. Useful for resetting test data or performing targeted data cleanup.
+
+```
+npx dexie-cloud clear-table <table>
+```
+
+### Options
+
+| Option | Meaning |
+| --- | --- |
+| `-Y, --yes` | Skip confirmation prompt |
+| `--db <Database-URL>` | Database URL (defaults to dexie-cloud.json) |
+
+### Example
+
+```
+# Clear all items from the 'todoItems' table (prompts for confirmation)
+npx dexie-cloud clear-table todoItems
+
+# Skip confirmation
+npx dexie-cloud clear-table todoItems --yes
+```
+
+### Remarks
+
+Requires `GLOBAL_WRITE` scope. This also removes any blobs and Y.js documents associated with the deleted objects.
+
+## clear-realm
+
+_Since dexie-cloud@3.0.4_
+
+Removes all objects, members, and Y.js data belonging to a specific realm across all tables. Validates shard availability upfront (all-or-nothing) to prevent partial deletes.
+
+```
+npx dexie-cloud clear-realm <realmId>
+```
+
+### Options
+
+| Option | Meaning |
+| --- | --- |
+| `-Y, --yes` | Skip confirmation prompt |
+| `--db <Database-URL>` | Database URL (defaults to dexie-cloud.json) |
+
+### Example
+
+```
+# Clear all data from a specific realm (prompts for confirmation)
+npx dexie-cloud clear-realm rlm-xyz123
+
+# Skip confirmation
+npx dexie-cloud clear-realm rlm-xyz123 --yes
+```
+
+### Remarks
+
+Requires `GLOBAL_WRITE` scope. This removes all objects, member entries, and Y.js collaborative documents belonging to the given realm. The realm entry itself is not deleted — only its contents.
+
 ## templates pull
 
 _Since 2024-01-31_


### PR DESCRIPTION
Documents the two new CLI commands added in dexie-cloud@3.0.4:

- `clear-table <table>` — wipes all objects from a given table (incl. blobs and Y.js data)
- `clear-realm <realmId>` — removes all objects, members, and Y.js data from a specific realm

Both support `-Y/--yes` to skip confirmation and `--db` to specify the database URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CLI docs for two new administrative commands:
    * clear-table — removes all objects from a specified table while preserving the database entry; supports an optional confirmation override and removes associated blobs and collaborative data.
    * clear-realm — removes all objects, membership entries, and collaborative data for a specified realm across tables; performs upfront validation to prevent partial deletes and requires global write permission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dexie/dexie-web/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->